### PR TITLE
Add a Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -57,11 +57,7 @@ further defined and clarified by project maintainers.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project team at [community@orbitdb.org](mailto:community@orbitdb.org), which goes to all members of the @OrbitDB community team, or to [richardlitt@orbitdb.org](mailto:richardlitt@orbitdb.org), which goes only to [@RichardLitt](https://github.com/RichardLitt) or to [haadcode@orbitdb.org](mailto:haadcode@orbitdb.org), which goes only to [@haadcode](https://github.com/haadcode).
 
-All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
@@ -73,4 +69,3 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage], versi
 available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 [homepage]: https://www.contributor-covenant.org
-

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [community@orbitdb.org](mailto:community@orbitdb.org), which goes to all members of the @OrbitDB community team, or to [richardlitt@orbitdb.org](mailto:richardlitt@orbitdb.org), which goes only to [@RichardLitt](https://github.com/RichardLitt) or to [haadcode@orbitdb.org](mailto:haadcode@orbitdb.org), which goes only to [@haadcode](https://github.com/haadcode).
+
+All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+

--- a/contributing.md
+++ b/contributing.md
@@ -47,11 +47,11 @@ We want to keep the OrbitDB community awesome, growing and collaborative. We nee
 
 - Stay on topic: Make sure that you are posting to the correct channel and avoid off-topic discussions. Remember when you update an issue or respond to an email you are potentially sending to a large number of people. Please consider this before you update. Also remember that nobody likes spam.
 
-There is also a more extensive [Code of conduct](CODE_OF_CONDUCT.md) which we follow, which can be found as part of the related Haja Networks organization.
+There is also a more extensive [Code of conduct](CODE_OF_CONDUCT.md) which we follow.
 
 #### Moderation
 
-In cases where community members transgress against the values above or in the Code, members of the OrbitDB organization members will use a three-strike warning system, where the aggressor will be warned twice before they are permanently excluded from OrbitDB community spaces. This code applies to Gitter, IRC, and GitHub, and any other future space that OrbitDB uses for communication. For interactions between OrbitDB community members outside of this space, the code also applies if the interactions are reported and deemed to be interfering with community members safely working on OrbitDB together. Moderation conversations, where more serious than simple warnings, will occur in private repositories or by email to ensure anonymity for reporters, and to ensure the safety of the moderators. To report an instance, please see the emails in the [Code of Conduct](CODE_OF_CONDUCT.md).
+In cases where community members transgress against the values above or in the Code, members of the OrbitDB organization members will use a three-strike warning system, where the aggressor will be warned twice before they are permanently excluded from OrbitDB community spaces. This code applies to Gitter, IRC, and GitHub, and any other future space that the OrbitDB community uses for communication. For interactions between OrbitDB community members outside of this space, the code also applies if the interactions are reported and deemed to be interfering with community members safely working on OrbitDB together. Moderation conversations, where more serious than simple warnings, will occur in private repositories or by email to ensure anonymity for reporters, and to ensure the safety of the moderators. To report an instance, please see the emails in the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ### Reporting Issues
 

--- a/contributing.md
+++ b/contributing.md
@@ -15,6 +15,7 @@ helping us improve our community.
 
 - [Security Issues](#security-issues)
 - [Community Guidelines](#community-guidelines)
+  - [Moderation](#moderation)
 - [Reporting Issues](#reporting-issues)
 - [Protocol Design](#protocol-design)
 - [Implementation Design](#implementation-design)
@@ -46,7 +47,11 @@ We want to keep the OrbitDB community awesome, growing and collaborative. We nee
 
 - Stay on topic: Make sure that you are posting to the correct channel and avoid off-topic discussions. Remember when you update an issue or respond to an email you are potentially sending to a large number of people. Please consider this before you update. Also remember that nobody likes spam.
 
-There is also a more extensive [Code of conduct](/code-of-conduct.md) which we follow, which can be found as part of the related Haja Networks organiaation.
+There is also a more extensive [Code of conduct](CODE_OF_CONDUCT.md) which we follow, which can be found as part of the related Haja Networks organization.
+
+#### Moderation
+
+In cases where community members transgress against the values above or in the Code, members of the OrbitDB organization members will use a three-strike warning system, where the aggressor will be warned twice before they are permanently excluded from OrbitDB community spaces. This code applies to Gitter, IRC, and GitHub, and any other future space that OrbitDB uses for communication. For interactions between OrbitDB community members outside of this space, the code also applies if the interactions are reported and deemed to be interfering with community members safely working on OrbitDB together. Moderation conversations, where more serious than simple warnings, will occur in private repositories or by email to ensure anonymity for reporters, and to ensure the safety of the moderators. To report an instance, please see the emails in the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ### Reporting Issues
 


### PR DESCRIPTION
This PR adds the Contributor Covenant Code of Conduct. It is the industry standard for open source projects at the moment, used by over 40,000 projects. While there are some issues with code of conducts in general - they can be perceived as threatening, they can suggest active moderation, and they may exclude certain viewpoints (if you're not aware of what I mean, let me know, and I can bring up examples) - they are overwhelmingly supported by communities that view healthy interactions as a core value, and by communities that are aim to be welcoming.

One of the issues with CoCs is that they imply rather than explicitly describe moderation procedures. I want to propose a three strike warning system, after which violators would be excluded from the community space. The moderators in charge would be the OrbitDB contributors - anyone who has push access to OrbitDB repositories. I've added a line to that affect in the Contributing guide, in this PR. If you have suggestions for a better system, let me know.

Another issue with CoCs is the scope. Here, I want to be clear that I am suggesting we use this Code for all of OrbitDB's interactions - on Gitter, on IRC, and in GitHub issues and PRs, and in any other place where OrbitDB moderators would exist (not including something like Twitter, where we don't moderate). If someone who is part of the community starts harassing someone offline or outside of OrbitDB's space, and it impacts the aggrieved's ability to work on OrbitDB, then we enter a gray area. Hopefully, this isn't an issue anytime soon. In such cases (which are not hypothetical - I've seen them happen and destroy members' involvement in projects), I think that we should proactively enforce the code by removing the aggressor from OrbitDB community spaces and especially from any position of power within the OrbitDB community (aka, no push rights.) This process should follow the three-strike process outlined above. 

This all sounds like a hassle. The point is that newcomers know that this is in place, so they feel like the can work on OrbitDB without having to deal with jerks. I think the initial hassle setting it up is worth that. 

I'd like a review from all of the @orbitdb/maintainers before merging. :) 