### PR TITLE
Add a task to the notetaking process

### DIFF
--- a/meeting-notes/templates/community-call.md
+++ b/meeting-notes/templates/community-call.md
@@ -21,4 +21,4 @@ _Show your work!_
 ## Q&A, Help Wanted
 _Ask questions, get answers. Announce issues that need help, get people to help._
 
-<!-- After each call, it is the responsibility of the notetaker to save the last version of the notes in a file in orbitdb/welcome/meeting-notes, by opening a branch and submitting a PR. -->
+<!-- After each call, it is the responsibility of the notetaker to save the last version of the notes in a file in orbitdb/welcome/meeting-notes, by opening a branch and submitting a PR. Then, post in the Gitter that the call is over, especially if it was a short call. -->


### PR DESCRIPTION
Right now, the notetaker is on call for adding the notes to the repository. However, they should also post in the Gitter, for the simple reason that Zoom does not indicate if a call has happened or not. That means that any community members who show up late may wonder if the call is working, and may ask where the notes are if they are not yet in the repository. Posting a simple message - "Hey, call is over, here are the notes" - obviates this problem.